### PR TITLE
Improve parser robustness and API ergonomics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.11'   # minimum supported version (see Project.toml compat)
+          - '1'      # latest stable release
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Unreleased
+
+### Changed
+- **Breaking:** `parse` is no longer exported. It is a distinct function from
+  `Base.parse`, and exporting it shadowed `Base.parse` for callers using
+  `using AAindex`. Call it as `AAindex.parse`.
+- `Index.data` is now typed `SVector{20, Float64}` and `Index.correlation` is
+  now `Dict{String, Float16}`, replacing the previous abstract element types.
+- `search` now returns results in a deterministic order (sorted by id, with any
+  exact id match first).
+- The package-wide index is held in a `const Ref`, making `search` and
+  `aaindex_by_id` lookups type-stable.
+
+### Fixed
+- `aaindex_by_id` no longer masks unrelated errors as "invalid identifier"; only
+  genuinely unknown ids raise an `ArgumentError`.
+- `parse` raises an `ArgumentError` for records with no `I`/`M` section instead
+  of failing with a `convert` error, and tolerates entries with missing tags.
+- `_parse_index` validates that exactly 20 values were parsed.
+- `_parse_correlations` no longer reads past the end of an odd token list.
+
+## [0.3.0]
+
+### Added
+- `transform` function for mapping amino acid sequences onto index values.
+- Amino acid handling based on BioSequences.
+
+### Removed
+- JLD2 dependency.
+
 ## [0.2.0] - 2020-12-19
 
 ### Added
 - Package provided copy of AAindex database files (v9.2)
-- `search`, `search_id`, and `is_key` utility functions for finding appropriate indices.
+- `search` and `is_key` utility functions for finding appropriate indices.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+AAindex.jl reads [AAindex](https://www.genome.jp/aaindex/) database files — flat-file
+records of physico-chemical and biochemical properties of amino acids. The package
+ships the v9.2 database files and downloads them on first use via DataDeps.
+
+## Commands
+
+```sh
+# Run the full test suite (uses test/Project.toml for test-only deps)
+julia --project=. -e 'using Pkg; Pkg.test()'
+
+# Instantiate dependencies
+julia --project=. -e 'using Pkg; Pkg.instantiate()'
+```
+
+There is no single-test runner. `test/runtests.jl` iterates over a hard-coded `tests`
+array and `include`s each file; to run a subset, temporarily edit that array. The test
+data files (`test_a1`, `test_index`, etc.) live in `test/testdata/testvars.jl` and are
+loaded once by `runtests.jl` before any test file runs — individual test files cannot
+be run standalone without that context.
+
+`DATADEPS_ALWAYS_ACCEPT` is set in `runtests.jl` so the database download is
+non-interactive during tests.
+
+## Architecture
+
+The data flow is: **raw flat-file record → `parse` → typed struct**, with an on-disk
+CSV index providing random access by accession number.
+
+- `src/init.jl` — `__init__` registers the `AAindex` DataDep (download URLs + SHA256s).
+  On first load it builds `index.csv` if absent, then assigns the module-global `INDEX`
+  (a `DataFrame`). The registry-CI branch skips all of this.
+- `src/data.jl` — `build_index` walks each `aaindexN` file, recording each entry's
+  byte `position`; `load_entry` seeks to that position and parses just that record.
+  This avoids holding the whole database in memory.
+- `src/parse.jl` — `parse(record::String)` turns one raw record into an `Index` or
+  `AMatrix`. AAindex records are tag-prefixed lines (`H`, `D`, `R`, `A`, `T`, `J`, `C`,
+  `I`, `M`, `*`); continuation lines start with whitespace and are folded into the
+  preceding tag's value. `I` → `Index`, `M` → `AMatrix`.
+- `src/index.jl` — type definitions (`Metadata`, `Index`, `AMatrix`), `getindex` for
+  looking up a value by `AminoAcid`, and `transform` (maps an amino-acid sequence to a
+  vector of index values). `sequence_to_amino_acids` accepts single-letter strings,
+  three-letter codes, `Char` vectors, or `AminoAcid` vectors.
+- `src/search.jl` — `search` and `aaindex_by_id` query the in-memory `INDEX` DataFrame.
+
+### Key conventions
+
+- The canonical amino-acid order is `ARNDCQEGHILKMFPSTWYV` (`AMINO_ACIDS` in `index.jl`);
+  `Index.data` is a 20-element `SVector` in that order.
+- `AMatrix` data is stored as `SHermitianCompact` when the record gives a lower-triangle
+  matrix, otherwise `SMatrix`. Row/column identities are raw strings from the record
+  header and are not guaranteed to be standard amino-acid labels.
+- `AAindex.parse` is intentionally *not* exported — it is a distinct function from
+  `Base.parse`, not a method of it, so exporting it would shadow `Base.parse`.
+
+## Notes
+
+- The database files are large and version-pinned by SHA256 in `src/init.jl`; updating
+  the AAindex release requires updating those hashes.
+- Tests run on GitHub Actions via `.github/workflows/CI.yml` (Julia 1.11 and latest).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AAindex"
 uuid = "1cd36ffe-cb05-4761-9ff9-f7bc1999e190"
 authors = ["Jonathan Chen <jwhc@ucla.edu>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ respective interfaces:
 
 ```julia-repl
 struct Index <: AbstractAAIndex
-    data::SVector{20}
-    correlation::Dict{String, AbstractFloat}
+    data::SVector{20, Float64}
+    correlation::Dict{String, Float16}
     metadata::Metadata
 end
 

--- a/src/AAindex.jl
+++ b/src/AAindex.jl
@@ -15,12 +15,16 @@ using StaticArrays
 
 import Base: getindex
 
-export 
+export
 # Types
-AbstractAAIndex, Metadata, Index, AMatrix, 
+AbstractAAIndex, Metadata, Index, AMatrix,
 
 # Functions
-parse, aaindex_by_id, search, transform
+aaindex_by_id, search, transform
+
+# Note: `parse` is intentionally not exported. It is a distinct function from
+# `Base.parse` (not a method of it); exporting it would shadow `Base.parse` for
+# anyone doing `using AAindex`. Call it as `AAindex.parse` instead.
 
 abstract type AbstractAAIndex end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -56,7 +56,7 @@ end
 
 Loads the entry with the given id from the index.
 """
-load_entry(id::AbstractString) = load_entry(INDEX, id)
+load_entry(id::AbstractString) = load_entry(INDEX[], id)
 
 function load_entry(index::DataFrame, id::AbstractString)
     record = only(subset(index, :id => ByRow(==(id))))

--- a/src/index.jl
+++ b/src/index.jl
@@ -44,8 +44,8 @@ physico-chemical and biochemical properties of amino acids.
 
 """
 struct Index <: AbstractAAIndex
-    data::SVector{20}
-    correlation::Dict{String, AbstractFloat}
+    data::SVector{20, Float64}
+    correlation::Dict{String, Float16}
     metadata::Metadata
 end
 
@@ -133,6 +133,14 @@ function sequence_to_amino_acids(sequence::AbstractVector{<:AbstractString})
     return aas
 end
 
+# Fallback for inputs none of the methods above can interpret, so callers get
+# an actionable message instead of a bare `MethodError`.
+sequence_to_amino_acids(sequence) = throw(ArgumentError(
+    "cannot interpret a value of type $(typeof(sequence)) as an amino acid " *
+    "sequence; provide a String, a Vector{Char}, a Vector of one- or " *
+    "three-letter code strings, or a Vector{AminoAcid}"
+))
+
 """
     transform(index::Index, sequence)
 
@@ -143,13 +151,13 @@ a string of single-letter codes, or a vector of strings (three-letter codes).
 # Examples
 
 ```julia
-julia> index = aaindex_by_id("KYTJ820101")
+julia> index = aaindex_by_id("KYTJ820101");
 
 julia> transform(index, [AA_A, AA_R, AA_N])
 [1.8, -4.5, -3.5]
 
 julia> transform(index, "ARN")
-[1.8, 1.8, 1.8]
+[1.8, -4.5, -3.5]
 
 julia> transform(index, ["ALA", "ARG", "ASN"])
 [1.8, -4.5, -3.5]
@@ -158,7 +166,7 @@ julia> transform(index, ["Ala", "Arg", "Asn"])
 [1.8, -4.5, -3.5]
 
 julia> transform(index, ["A", "Arg", "n"])
-[1.1, -5.1, -3.5]
+[1.8, -4.5, -3.5]
 ```
 """
 transform(index::Index, sequence::AbstractVector{AminoAcid}) =

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,3 +1,7 @@
+# The package-wide index of entries, populated by `__init__`. A `const` `Ref`
+# keeps lookups type-stable (a non-const global would not be).
+const INDEX = Ref{DataFrame}()
+
 function __init__()
     if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
         # Do not trigger or require download here
@@ -44,6 +48,6 @@ function __init__()
         end
 
         # load index so that it is available for use in the package
-        global INDEX = load_index()
+        INDEX[] = load_index()
     end
 end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -4,15 +4,20 @@ const ENTRY_SYMBOLS = "HDRATJCIM*"
 """
     parse(record)
 
-Parses given AAindex `entry`.
+Parses the given AAindex `record` (the raw text of one database entry) into an
+[`Index`](@ref) or [`AMatrix`](@ref).
+
+Throws an `ArgumentError` if the record contains neither an `I` (index) nor an
+`M` (matrix) section.
 """
 function parse(record::String)::AbstractAAIndex
-    pairs = Dict()
+    pairs = Dict{Char,Any}()
     lines = map(String, split(record, '\n', keepempty=false))
 
     while !isempty(lines) && first(lines) != "//"
         line = popfirst!(lines)
-        tag, value = line[1], strip(line[3:end])
+        tag = line[1]
+        value = length(line) > 2 ? strip(line[3:end]) : ""
 
         while !isempty(lines) && isspace(first(first(lines)))
             value *= " " * popfirst!(lines)
@@ -20,29 +25,32 @@ function parse(record::String)::AbstractAAIndex
 
         push!(pairs, tag => value)
     end
-    
+
     if 'R' in keys(pairs)
         pairs['R'] = map(String, split(pairs['R'], " "))
     end
 
     metadata = Metadata(
-        pairs['H'],
-        pairs['D'],
-        'R' in keys(pairs) ? pairs['R'] : String[],
-        pairs['J'],
-        pairs['T'],
-        pairs['A'],
-        '*' in keys(pairs) ? pairs['*'] : ""
+        get(pairs, 'H', ""),
+        get(pairs, 'D', ""),
+        get(pairs, 'R', String[]),
+        get(pairs, 'J', ""),
+        get(pairs, 'T', ""),
+        get(pairs, 'A', ""),
+        get(pairs, '*', "")
     )
 
     if 'M' in keys(pairs)
         return AMatrix(_parse_matrix(pairs['M'])..., metadata)
     elseif 'I' in keys(pairs)
-        return Index(
-            _parse_index(pairs['I']),
-            _parse_correlations(pairs['C']),
-            metadata
-        )
+        correlations = 'C' in keys(pairs) ?
+            _parse_correlations(pairs['C']) : Dict{String,Float16}()
+        return Index(_parse_index(pairs['I']), correlations, metadata)
+    else
+        throw(ArgumentError(
+            "AAindex record \"$(metadata.id)\" has neither an I (index) " *
+            "nor an M (matrix) section"
+        ))
     end
 end
 
@@ -54,11 +62,19 @@ end
 
 function _parse_index(data::AbstractString)
     data = replace(data, "NA" => "NaN")
-    data = split(data, r"\s+", keepempty=false)
+    tokens = split(data, r"\s+", keepempty=false)
 
-    values = filter(x -> !isnothing(x), map(x -> tryparse(Float64, x), data))
-        
-    SVector{length(values)}(values)
+    values = Float64[]
+    for token in tokens
+        value = tryparse(Float64, token)
+        isnothing(value) || push!(values, value)
+    end
+
+    length(values) == 20 || throw(ArgumentError(
+        "expected 20 amino acid index values, parsed $(length(values))"
+    ))
+
+    SVector{20,Float64}(values)
 end
 
 
@@ -75,7 +91,7 @@ function _parse_matrix(data::AbstractString)
 
     m, n = length(rowids), length(columnids)
     data = zeros(m, n)
-    
+
     # check if matrix is lower triangular
     if length(values) < m * n
         indices = [(x, y) for x in 1:m for y in 1:x]
@@ -101,12 +117,13 @@ end
 
 
 function _parse_correlations(data::AbstractString)
-    tokens = split(data, r"\s", keepempty=false)
-    values = []
+    tokens = split(data, r"\s+", keepempty=false)
+    pairs = Pair{String,Float16}[]
 
-    for i = 1:2:length(tokens)
-        push!(values, String(tokens[i]) => tryparse(Float16, tokens[i+1]))
+    for i in 1:2:length(tokens)-1
+        value = tryparse(Float16, tokens[i+1])
+        isnothing(value) || push!(pairs, String(tokens[i]) => value)
     end
 
-    Dict(values)
+    Dict(pairs)
 end

--- a/src/search.jl
+++ b/src/search.jl
@@ -11,29 +11,36 @@ end
 """
     aaindex_by_id(id::String)
 
-Load an AAindex by its id.
+Load an AAindex entry by its accession number.
+
+Throws an `ArgumentError` if `id` is not present in the index. Errors raised
+while reading or parsing a valid entry are *not* masked — they propagate
+unchanged.
 """
-aaindex_by_id(id::AbstractString) = aaindex_by_id(INDEX, id)
+aaindex_by_id(id::AbstractString) = aaindex_by_id(INDEX[], id)
 
 function aaindex_by_id(index::DataFrame, id::AbstractString)
-    try
-        return load_entry(index, id)
-    catch
+    matches = subset(index, :id => ByRow(==(id)))
+
+    if nrow(matches) != 1
         throw(ArgumentError("$id is not a valid AAindex identifier"))
     end
+
+    load_entry(index, id)
 end
 
 
 """
     search(term::AbstractString)
 
-Search for AAindex entries by term based on id and description. Returns a list of
-ids and descriptions that match the term.
+Search for AAindex entries by term based on id and description. Returns a list
+of `(id, description)` pairs that match the term, sorted by id with any exact
+id match first.
 """
-search(term::AbstractString) = search(INDEX, term)
+search(term::AbstractString) = search(INDEX[], term)
 
 function search(index::DataFrame, term::AbstractString)
-    match_indices = Set()
+    match_indices = Set{Int}()
 
     for (i, id) in enumerate(index.id)
         if id == term
@@ -41,11 +48,17 @@ function search(index::DataFrame, term::AbstractString)
         end
     end
 
+    needle = lowercase(term)
     for (i, description) in enumerate(index.description)
-        if occursin(term |> lowercase, description |> lowercase)
+        if occursin(needle, lowercase(description))
             push!(match_indices, i)
         end
     end
 
-    [(; id = index[i, :id], description = index[i, :description]) for i in match_indices]
+    results = [
+        (; id = index[i, :id], description = index[i, :description])
+        for i in match_indices
+    ]
+
+    sort!(results, by = r -> (r.id != term, r.id))
 end

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,5 +1,30 @@
 @testset "Index" begin
-    # Test transform
     index = aaindex_by_id("KYTJ820101")
-    @test AAindex.transform(index, "AAA") == [1.8, 1.8, 1.8]
+
+    @testset "field types are concrete" begin
+        @test index.data isa AAindex.SVector{20,Float64}
+        @test index.correlation isa Dict{String,Float16}
+    end
+
+    @testset "getindex by amino acid" begin
+        @test index[AAindex.AminoAcid('A')] == 1.8
+        @test index[AAindex.AminoAcid('R')] == -4.5
+    end
+
+    @testset "transform" begin
+        @test transform(index, "AAA") == [1.8, 1.8, 1.8]
+        @test transform(index, "ARN") == [1.8, -4.5, -3.5]
+    end
+
+    @testset "transform is case-insensitive for single-letter codes" begin
+        @test transform(index, "arn") == [1.8, -4.5, -3.5]
+    end
+
+    @testset "transform accepts three-letter codes of any case" begin
+        @test transform(index, ["Ala", "ARG", "asn"]) == [1.8, -4.5, -3.5]
+    end
+
+    @testset "transform rejects unsupported sequence types" begin
+        @test_throws ArgumentError transform(index, 123)
+    end
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -60,4 +60,10 @@
         @test parsed.data[1, 1] == -0.94
         @test parsed.data[1, 2] == 1.26
     end
+
+    @testset "parse is not exported (does not shadow Base.parse)" begin
+        @test !(:parse in names(AAindex))
+        # still reachable as a qualified name
+        @test AAindex.parse(test_a1) isa AAindex.Index
+    end
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -10,10 +10,54 @@
         @test AAindex._parse_index(test_index) == test_index_result
     end
 
+    @testset "Parse Index rejects wrong length" begin
+        @test_throws ArgumentError AAindex._parse_index("I 1.0 2.0 3.0")
+    end
+
     @testset "Parse entry" begin
         parsed = AAindex.parse(test_a1)
 
+        @test parsed isa AAindex.Index
         @test parsed.metadata.id == AAindex.parse_id(test_a1)
         @test parsed.data == test_index_result
+    end
+
+    @testset "Parse index with missing value" begin
+        parsed = AAindex.parse(test_index_with_na)
+
+        @test parsed isa AAindex.Index
+        # the R/K column, position 2, holds the NA
+        @test isnan(parsed.data[2])
+    end
+
+    @testset "Parse index without correlations" begin
+        parsed = AAindex.parse(test_index_no_c)
+
+        @test parsed isa AAindex.Index
+        @test isempty(parsed.correlation)
+    end
+
+    @testset "Parse record with no data section throws" begin
+        @test_throws ArgumentError AAindex.parse(test_no_data_record)
+    end
+
+    @testset "Parse lower-triangular matrix" begin
+        parsed = AAindex.parse(test_a2)
+
+        @test parsed isa AAindex.AMatrix
+        @test parsed.data isa AAindex.SHermitianCompact
+        @test parsed.data[1, 1] == 3.0
+        @test parsed.data[2, 1] == -3.0
+        # stored as Hermitian, so the matrix is symmetric
+        @test parsed.data[1, 2] == -3.0
+    end
+
+    @testset "Parse full matrix" begin
+        parsed = AAindex.parse(test_full_matrix_record)
+
+        @test parsed isa AAindex.AMatrix
+        @test parsed.data isa AAindex.SMatrix
+        @test parsed.data[1, 1] == -0.94
+        @test parsed.data[1, 2] == 1.26
     end
 end

--- a/test/search.jl
+++ b/test/search.jl
@@ -17,9 +17,23 @@
         @test description == expected_description
 
         result = aaindex_by_id(id)
-        
+
         @test result isa AAindex.AMatrix
         @test result.metadata.description == expected_description
+    end
+
+    @testset "search returns results in a deterministic, sorted order" begin
+        results = search("hydrophobicity")
+        ids = [r.id for r in results]
+
+        @test issorted(ids)
+        @test ids == [r.id for r in search("hydrophobicity")]
+    end
+
+    @testset "aaindex_by_id rejects unknown ids" begin
+        @test_throws ArgumentError aaindex_by_id("NOTANID000")
+        # the error message should name the offending id
+        @test_throws "NOTANID000" aaindex_by_id("NOTANID000")
     end
 
 end

--- a/test/testdata/testvars.jl
+++ b/test/testdata/testvars.jl
@@ -135,3 +135,48 @@ M rows = ARNDCQEGHILKMFPSTWYV, cols = ARNDCQEGHILKMFPSTWYV
   -0.88 -0.20 -0.29 0.14 -1.31  0.09 0.71 -0.56 -0.57 -1.66 -1.38  1.40 -1.60 -1.97 -0.73 -0.32 -0.37  -1.40 -0.96 -1.38
   -1.74  0.85  0.24 0.72 -2.25  0.45 0.81 -1.29 -0.24 -2.46 -2.38  0.37 -1.21 -2.16 -1.00 -0.10 -0.57  -1.34 -1.52 -2.31
 """
+
+# A complete index record containing a missing value (NA).
+test_index_with_na = """
+H TEST000001
+D test entry with a missing value
+R LIT:0 PMID:0
+A Tester
+T A test entry
+J Test Journal
+C BUNA790102    0.949
+I    A/L     R/K     N/M     D/F     C/P     Q/S     E/T     G/W     H/Y     I/V
+    4.35    NA      4.75    4.76    4.65    4.37    4.29    3.97    4.63    3.95
+    4.17    4.36    4.52    4.66    4.44    4.50    4.35    4.70    4.60    3.95
+//
+"""
+
+# A complete index record with no C (correlation) section.
+test_index_no_c = """
+H TEST000002
+D test entry without correlations
+R LIT:0 PMID:0
+A Tester
+T A test entry
+J Test Journal
+I    A/L     R/K     N/M     D/F     C/P     Q/S     E/T     G/W     H/Y     I/V
+    4.35    4.38    4.75    4.76    4.65    4.37    4.29    3.97    4.63    3.95
+    4.17    4.36    4.52    4.66    4.44    4.50    4.35    4.70    4.60    3.95
+//
+"""
+
+# A record with neither an I (index) nor M (matrix) section.
+test_no_data_record = """
+H TEST000003
+D record with no data section
+R LIT:0 PMID:0
+A Tester
+T A test entry
+J Test Journal
+//
+"""
+
+# A complete matrix record whose data is a full (non-triangular) matrix.
+test_full_matrix_record =
+    "H TEST000004\nD full matrix entry\nR PMID:0\nA Tester\n" *
+    "T A test entry\nJ Test Journal\n" * test_non_triangular_matrix * "//\n"


### PR DESCRIPTION
Deep-review pass over the package focused on **correctness** and **ergonomics**, plus project tooling. Each commit is self-contained and the full suite passes at every commit (56 tests, up from 26).

## Correctness

- **`parse`**: records with no `I`/`M` section now raise an `ArgumentError` instead of failing with a `Nothing`-to-`AbstractAAIndex` `convert` error. Missing metadata tags default gracefully rather than throwing `KeyError`, and index entries with no `C` (correlation) section are accepted.
- **`_parse_index`**: validates that exactly 20 values were parsed.
- **`_parse_correlations`**: no longer reads past the end of an odd token list (latent `BoundsError`).
- **`aaindex_by_id`**: checks for the id explicitly and no longer masks unrelated read/parse errors as `"invalid identifier"`.
- **`search`**: returns results in a deterministic order (sorted by id, exact id match first) instead of an unordered `Set`.

## Ergonomics

- The package-wide index is held in a `const Ref{DataFrame}`, making `search`/`aaindex_by_id` lookups type-stable.
- `Index.data` is now `SVector{20,Float64}` and `Index.correlation` is `Dict{String,Float16}`, replacing abstract element types.
- `sequence_to_amino_acids` has a fallback that raises an actionable `ArgumentError` instead of a bare `MethodError`.
- `transform` docstring examples corrected.

## ⚠️ Breaking change

`parse` is **no longer exported** — it is a distinct function from `Base.parse`, and exporting it shadowed `Base.parse` for callers using `using AAindex`. Call it as `AAindex.parse`. Version bumped to `0.4.0`.

## Tooling

- Added `CLAUDE.md` (architecture/commands guide).
- Added a GitHub Actions CI workflow that runs the test suite on Julia 1.11 and latest (previously only CompatHelper/TagBot).
- Brought `CHANGELOG.md` up to date.

## Testing

`julia --project=. -e 'using Pkg; Pkg.test()'` — 56/56 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)