### PR TITLE
Address code review feedback from PR #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `using AAindex`. Call it as `AAindex.parse`.
 - `Index.data` is now typed `SVector{20, Float64}` and `Index.correlation` is
   now `Dict{String, Float16}`, replacing the previous abstract element types.
+  `Metadata.reference` is now `Vector{String}` and `AMatrix.data`'s element
+  type is pinned to `Float64`, completing the move to concrete field types.
 - `search` now returns results in a deterministic order (sorted by id, with any
   exact id match first).
 - The package-wide index is held in a `const Ref`, making `search` and
   `aaindex_by_id` lookups type-stable.
+- `is_key` now requires an exact (anchored) match and accepts any
+  `AbstractString` rather than only `String`.
 
 ### Fixed
 - `aaindex_by_id` no longer masks unrelated errors as "invalid identifier"; only
   genuinely unknown ids raise an `ArgumentError`.
 - `parse` raises an `ArgumentError` for records with no `I`/`M` section instead
   of failing with a `convert` error, and tolerates entries with missing tags.
+- `parse` no longer carries an abstract `::AbstractAAIndex` return annotation,
+  so callers can infer the concrete `Union{Index, AMatrix}`.
 - `_parse_index` validates that exactly 20 values were parsed.
 - `_parse_correlations` no longer reads past the end of an odd token list.
+- Matrix parsing correctly handles a lone `-` missing-value marker; it
+  previously consumed surrounding whitespace and corrupted neighbouring values.
+- `build_index` reports the source file and offset of an entry that fails to
+  parse, and accessing the index before it is loaded raises a clear error
+  rather than an `UndefRefError`.
 
 ## [0.3.0]
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -22,7 +22,13 @@ function build_index(
 
             while !eof(io)
                 entry = readuntil(io, "//\n")
-                record = parse(entry)
+                record = try
+                    parse(entry)
+                catch err
+                    error("failed to parse the entry at position " *
+                          "$entry_position in $database_file: " *
+                          sprint(showerror, err))
+                end
 
                 push!(entry_records, (;
                     aaindex = database_file,
@@ -56,7 +62,7 @@ end
 
 Loads the entry with the given id from the index.
 """
-load_entry(id::AbstractString) = load_entry(INDEX[], id)
+load_entry(id::AbstractString) = load_entry(index(), id)
 
 function load_entry(index::DataFrame, id::AbstractString)
     record = only(subset(index, :id => ByRow(==(id))))

--- a/src/index.jl
+++ b/src/index.jl
@@ -31,7 +31,7 @@ Each entry has the following format:
 struct Metadata
     id::String
     description::String
-    reference::Array{String}
+    reference::Vector{String}
     journal::String
     title::String
     authors::String
@@ -89,7 +89,11 @@ Each entry has the following format:
 struct AMatrix <: AbstractAAIndex
     rowids::String
     columnids::String
-    data::Union{SHermitianCompact, SMatrix}
+    # The container shape varies (lower-triangular vs. full), but the element
+    # type is always Float64; pinning it keeps the field as concrete as the
+    # shape variation allows.
+    data::Union{SHermitianCompact{N,Float64} where N,
+                SMatrix{M,N,Float64} where {M,N}}
     metadata::Metadata
 end
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -2,6 +2,21 @@
 # keeps lookups type-stable (a non-const global would not be).
 const INDEX = Ref{DataFrame}()
 
+"""
+    index()
+
+Returns the package-wide index of AAindex entries. The index is loaded
+automatically by `__init__` when the package is imported; this accessor
+raises a clear error if it is somehow accessed before then.
+"""
+function index()
+    isassigned(INDEX) || error(
+        "the AAindex index has not been loaded; it is normally loaded " *
+        "automatically when AAindex is imported"
+    )
+    INDEX[]
+end
+
 function __init__()
     if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
         # Do not trigger or require download here

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,6 +1,3 @@
-
-const ENTRY_SYMBOLS = "HDRATJCIM*"
-
 """
     parse(record)
 
@@ -10,7 +7,7 @@ Parses the given AAindex `record` (the raw text of one database entry) into an
 Throws an `ArgumentError` if the record contains neither an `I` (index) nor an
 `M` (matrix) section.
 """
-function parse(record::String)::AbstractAAIndex
+function parse(record::String)
     pairs = Dict{Char,Any}()
     lines = map(String, split(record, '\n', keepempty=false))
 
@@ -83,11 +80,20 @@ function _parse_matrix(data::AbstractString)
     header, data = data[header_idx], data[header_idx.stop+1:end]
     rowids, columnids = [header[idx] for idx in findall(r"[A-Z\-]+", header)]
 
-    data = replace(data, "NA" => "NaN")
-    data = replace(data, r"\s-\s" => "NaN")
-    data = split(data, r"\s+", keepempty=false)
+    # A token is parsed value-by-value rather than with a regex substitution:
+    # a lone "-" (or "NA") marks a missing value, and splitting first avoids
+    # the boundary/adjacency hazards of rewriting whitespace-delimited markers.
+    tokens = split(data, r"\s+", keepempty=false)
 
-    values = filter(x -> !isnothing(x), map(x -> tryparse(Float64, x), data))
+    values = Float64[]
+    for token in tokens
+        if token == "-" || token == "NA"
+            push!(values, NaN)
+        else
+            value = tryparse(Float64, token)
+            isnothing(value) || push!(values, value)
+        end
+    end
 
     m, n = length(rowids), length(columnids)
     data = zeros(m, n)

--- a/src/search.jl
+++ b/src/search.jl
@@ -1,11 +1,11 @@
 """
     is_key(candidate)
 
-Checks if provided candidate key matches the format for AAindex accession
-numbers.
+Checks whether `candidate` is exactly an AAindex accession number (four word
+characters followed by six digits).
 """
-function is_key(candidate::String)::Bool
-    match(r"\w{4}\d{6}", candidate) !== nothing
+function is_key(candidate::AbstractString)::Bool
+    match(r"^\w{4}\d{6}$", candidate) !== nothing
 end
 
 """
@@ -17,7 +17,7 @@ Throws an `ArgumentError` if `id` is not present in the index. Errors raised
 while reading or parsing a valid entry are *not* masked — they propagate
 unchanged.
 """
-aaindex_by_id(id::AbstractString) = aaindex_by_id(INDEX[], id)
+aaindex_by_id(id::AbstractString) = aaindex_by_id(index(), id)
 
 function aaindex_by_id(index::DataFrame, id::AbstractString)
     matches = subset(index, :id => ByRow(==(id)))
@@ -37,7 +37,7 @@ Search for AAindex entries by term based on id and description. Returns a list
 of `(id, description)` pairs that match the term, sorted by id with any exact
 id match first.
 """
-search(term::AbstractString) = search(INDEX[], term)
+search(term::AbstractString) = search(index(), term)
 
 function search(index::DataFrame, term::AbstractString)
     match_indices = Set{Int}()

--- a/test/index.jl
+++ b/test/index.jl
@@ -4,6 +4,7 @@
     @testset "field types are concrete" begin
         @test index.data isa AAindex.SVector{20,Float64}
         @test index.correlation isa Dict{String,Float16}
+        @test fieldtype(AAindex.Metadata, :reference) == Vector{String}
     end
 
     @testset "getindex by amino acid" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -61,6 +61,25 @@
         @test parsed.data[1, 2] == 1.26
     end
 
+    @testset "Parse matrix with a missing value" begin
+        parsed = AAindex.parse(test_matrix_with_missing)
+
+        @test parsed isa AAindex.AMatrix
+        @test parsed.data isa AAindex.SMatrix
+        @test parsed.data[1, 1] == 1.0
+        # a lone "-" marks a missing value
+        @test isnan(parsed.data[1, 2])
+        @test parsed.data[2, 1] == 3.0
+        @test parsed.data[2, 2] == 4.0
+    end
+
+    @testset "AMatrix.data is concretely typed" begin
+        # the element type is pinned even though the container shape varies
+        @test fieldtype(AAindex.AMatrix, :data) ==
+            Union{AAindex.SHermitianCompact{N,Float64} where N,
+                  AAindex.SMatrix{M,N,Float64} where {M,N}}
+    end
+
     @testset "parse is not exported (does not shadow Base.parse)" begin
         @test !(:parse in names(AAindex))
         # still reachable as a qualified name

--- a/test/search.jl
+++ b/test/search.jl
@@ -5,6 +5,13 @@
         @test AAindex.is_key("CORJ870107")
         @test !AAindex.is_key("701078JROC")
         @test !AAindex.is_key("COJ80107")
+
+        # the match must be anchored: surrounding characters are not a key
+        @test !AAindex.is_key("CORJ870107XX")
+        @test !AAindex.is_key("XXCORJ870107")
+
+        # any AbstractString is accepted, not just String
+        @test AAindex.is_key(SubString("xCORJ870107", 2))
     end
 
     @testset "search" begin

--- a/test/testdata/testvars.jl
+++ b/test/testdata/testvars.jl
@@ -180,3 +180,17 @@ J Test Journal
 test_full_matrix_record =
     "H TEST000004\nD full matrix entry\nR PMID:0\nA Tester\n" *
     "T A test entry\nJ Test Journal\n" * test_non_triangular_matrix * "//\n"
+
+# A matrix record with a lone "-" marking a missing value (data[1,2]).
+test_matrix_with_missing = """
+H TEST000005
+D matrix entry with a missing value
+R PMID:0
+A Tester
+T A test entry
+J Test Journal
+M rows = AR, cols = AR
+    1.0 -
+    3.0 4.0
+//
+"""


### PR DESCRIPTION
Follow-up to #6, addressing the issues raised by post-merge code review. No behaviour the original PR intended is changed; this tightens the loose ends. **67 tests pass** (up from 56).

## Type stability / concreteness

- **`parse` no longer carries a `::AbstractAAIndex` return annotation.** The abstract annotation forced inference to `AbstractAAIndex`; without it, callers now infer the concrete `Union{Index, AMatrix}` (verified with `Base.infer_return_type`). This was quietly undercutting the type-stability goal of #6.
- **`Metadata.reference`** narrowed to `Vector{String}` (was `Array{String}`, an abstract `UnionAll`).
- **`AMatrix.data`** element type pinned to `Float64`, completing the concrete-field-types pass.

## Correctness

- **`_parse_matrix` lone-`-` handling fixed.** The `replace(data, r"\s-\s" => "NaN")` substitution consumed the whitespace separators around a missing-value marker, gluing tokens together (e.g. `1.0 - 3.0` → `1.0NaN3.0`). It only survived on real data because AAindex2 pads columns with multiple spaces. Now markers are detected per-token after splitting. New test covers a record with a lone `-`.
- **`is_key`** is now an exact-match validator (anchored regex `^\w{4}\d{6}$`) — previously it matched accession numbers as substrings, so `"XXCORJ870107YY"` was reported as a key. Also accepts any `AbstractString`.

## Robustness / ergonomics

- Added a guarded **`index()` accessor**: accessing the package index before `__init__` loads it now raises a clear error instead of an `UndefRefError`. `aaindex_by_id`, `search`, and `load_entry` route through it.
- **`build_index`** now reports the source file and byte offset of any entry that fails to parse, instead of aborting the whole build with a context-free error.
- Removed the unused `ENTRY_SYMBOLS` constant.

## Notes

- The CHANGELOG keeps `[0.4.0] - Unreleased`; these changes are folded into that section since 0.4.0 isn't tagged/registered yet.
- One review comment (CHANGELOG should carry a release date) was intentionally **not** applied — 0.4.0 is deliberately unreleased and accumulating changes.

## Testing

`julia --project=. -e 'using Pkg; Pkg.test()'` — 67/67 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)