### PR TITLE
Prepare 0.4.0 release: README refresh + changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.4.0] - 2026-05-17
 
 ### Added
 - `show` methods for `Index`, `AMatrix`, and `Metadata`, so they no longer

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 A package to read [AAindex](https://www.genome.jp/aaindex/) database files.
 These contain a variety of reported physico-chemical and biochemical
-properties of amino acids (Kawashima and Kanehisa, 2000). The package now
-also provides a copy of the database files (v9.2) for convenience. However,
-you may still use your own copy if you want to.
+properties of amino acids (Kawashima and Kanehisa, 2000). The package ships a
+copy of the database files (v9.2) and downloads them on first use, so no manual
+setup is required. You may still point the package at your own copy if you
+prefer.
 
 ## Usage
 
-The main interface provided by this package is the `search` function, which
-accepts a search term (_e.g._, `ANDN920101` or `hydrophobicity`) and,
-optionally, a path to an AAindex database file. It will search through the
-database and return a list of matching database entries. Additionally, the
-`aaindex_by_id` function provides a more direct interface for loading a specific
-entry.
+### Searching for entries
+
+`search` accepts a search term (_e.g._, `ANDN920101` or `hydrophobicity`) and
+returns a sorted list of matching `(id, description)` pairs. Matching is
+case-insensitive and covers each entry's id, description, title, and authors;
+an exact id match sorts first.
 
 ```julia-repl
 julia> search("hydrophobicity")
@@ -21,22 +22,36 @@ julia> search("hydrophobicity")
  (id = "ARGP820101", description = "Hydrophobicity index (Argos et al., 1982)")
  (id = "BASU050101", description = "Interactivity scale obtained from the contact matrix (Bastolla et al., 2005)")
  (id = "BASU050102", description = "Interactivity scale obtained by maximizing the mean of correlation   coefficient over single-domain globular proteins (Bastolla et al., 2005)")
- (id = "BASU050103", description = "Interactivity scale obtained by maximizing the mean of correlation   coefficient over pairs of sequences sharing the TIM barrel fold (Bastolla et    al., 2005)")
- (id = "BIGC670101", description = "Residue volume (Bigelow, 1967)")
- (id = "BLAS910101", description = "Scaled side chain hydrophobicity values (Black-Mould, 1991)")
- (id = "BULH740101", description = "Transfer free energy to surface (Bull-Breese, 1974)")
- (id = "BULH740102", description = "Apparent partial specific volume (Bull-Breese, 1974)")
- (id = "CASG920101", description = "Hydrophobicity scale from native protein structures (Casari-Sippl, 1992)")
  ⋮
- (id = "WIMW960101", description = "Free energies of transfer of AcWl-X-LL peptides from bilayer interface to   water (Wimley-White, 1996)")
- (id = "WOLR790101", description = "Hydrophobicity index (Wolfenden et al., 1979)")
- (id = "YUTK870101", description = "Unfolding Gibbs energy in water, pH7.0 (Yutani et al., 1987)")
- (id = "YUTK870102", description = "Unfolding Gibbs energy in water, pH9.0 (Yutani et al., 1987)")
- (id = "YUTK870103", description = "Activation Gibbs energy of unfolding, pH7.0 (Yutani et al., 1987)")
  (id = "YUTK870104", description = "Activation Gibbs energy of unfolding, pH9.0 (Yutani et al., 1987)")
  (id = "ZASB820101", description = "Dependence of partition coefficient on ionic strength (Zaslavsky et al.,   1982)")
  (id = "ZIMJ680101", description = "Hydrophobicity (Zimmerman et al., 1968)")
+```
 
+Calling `search()` with no arguments returns every entry in the database, in
+the same `(id, description)` shape. `ids()` returns just the accession numbers
+as a sorted `Vector{String}`.
+
+```julia-repl
+julia> search()
+707-element Vector{@NamedTuple{id::String, description::String}}:
+ ⋮
+
+julia> ids()
+707-element Vector{String}:
+ "ALTS910101"
+ "ANDN920101"
+ "ARGP820101"
+ ⋮
+```
+
+### Loading an entry
+
+`aaindex_by_id` loads a specific entry by its accession number. It returns
+either an `Index` (a set of 20 per-amino-acid values) or an `AMatrix` (a
+mutation or contact-potential matrix), depending on the record.
+
+```julia-repl
 julia> index = aaindex_by_id("JURD980101")
 Index JURD980101
   Modified Kyte-Doolittle hydrophobicity scale (Juretic et al., 1998)
@@ -62,12 +77,16 @@ Index JURD980101
     Y => -1.3
     V => 4.2
   79 correlated entries
+
+julia> aaindex_by_id("ALTS910101")
+AMatrix ALTS910101
+  The PAM-120 matrix (Altschul, 1991)
+  20×20 matrix (rows: ARNDCQEGHILKMFPSTWYV, cols: ARNDCQEGHILKMFPSTWYV)
 ```
 
-This returns an array of `Index` and `AMatrix` objects with the following
-respective interfaces:
+`Index` and `AMatrix` have the following respective interfaces:
 
-```julia-repl
+```julia
 struct Index <: AbstractAAIndex
     data::Vector{Union{Missing, Float64}}
     correlation::Dict{String, Float16}
@@ -82,13 +101,18 @@ struct AMatrix <: AbstractAAIndex
 end
 ```
 
-Entry metadata is stored in a separate struct with the following interface:
+`Index.data` holds 20 values in the canonical `ARNDCQEGHILKMFPSTWYV` order.
+AAindex marks unavailable values with `NA`; these are represented as `missing`
+(not `NaN`), so a gap never silently poisons an aggregate — use `skipmissing`
+to opt in to handling them.
 
-```julia-repl
+Entry metadata is stored in a separate struct:
+
+```julia
 struct Metadata
     id::String
     description::String
-    reference::Array{String}
+    reference::Vector{String}
     journal::String
     title::String
     authors::String
@@ -96,8 +120,48 @@ struct Metadata
 end
 ```
 
+### Looking up values
+
+An `Index` can be indexed by a `BioSequences.AminoAcid`, a single-letter
+`Char`, or a one- or three-letter code string:
+
+```julia-repl
+julia> index['A']
+1.1
+
+julia> index["A"]
+1.1
+
+julia> index["ALA"]
+1.1
+```
+
+An `AMatrix` can be indexed by an integer pair or by an amino-acid pair, and
+reports its dimensions via `size`. Note that a matrix's row/column identities
+come straight from the source record and are not guaranteed to be standard
+amino-acid labels.
+
+```julia-repl
+julia> matrix = aaindex_by_id("ALTS910101");
+
+julia> size(matrix)
+(20, 20)
+
+julia> matrix[5, 18]
+-8.0
+
+julia> using BioSequences: AA_C, AA_W
+
+julia> matrix[AA_C, AA_W]
+-8.0
+```
+
+### Transforming sequences
+
 Amino acid sequences can be transformed into vectors of values from an index
-using the `transform` function.
+using the `transform` function. The sequence may be a string of single-letter
+codes, a vector of `Char`s, a vector of one- or three-letter code strings, or a
+vector of `AminoAcid`s.
 
 ```julia-repl
 julia> transform(index, "ARN")
@@ -107,8 +171,8 @@ julia> transform(index, "ARN")
  -3.5
 ```
 
-You can use the `transform` function to calculate the average value of an index
-over a sequence.
+You can use `transform` to calculate the average value of an index over a
+sequence.
 
 ```julia-repl
 julia> using Statistics
@@ -117,20 +181,29 @@ julia> transform(index, ["Ala", "Arg", "Asn"]) |> mean
 -2.5
 ```
 
-You can also define your own functions to calculate properties of a sequence. For example, here is a function that calculates the GRAVY (Grand Average of Hydropathy) metric of a sequence.
+You can also define your own functions to calculate properties of a sequence.
+For example, here is a function that calculates the GRAVY (Grand Average of
+Hydropathy) metric of a sequence.
 
 ```julia-repl
 julia> function gravy(sequence)
-    # use the Kyte-Doolittle hydropathy index
-    index = aaindex_by_id("KYTJ820101")
-    hydropathies = transform(index, sequence)
+           # use the Kyte-Doolittle hydropathy index
+           index = aaindex_by_id("KYTJ820101")
+           hydropathies = transform(index, sequence)
 
-    sum(hydropathies) / length(sequence)
-end
+           sum(hydropathies) / length(sequence)
+       end
 
 julia> gravy("LLGDFFRKSKEKIGKEFKRIVQRIKDFLRNLVPRTES")
 -0.7243243243243245
 ```
+
+### Parsing raw records
+
+To parse the raw text of a single AAindex record directly, use
+`AAindex.parse`. It is intentionally *not* exported: it is a distinct function
+from `Base.parse`, and exporting it would shadow `Base.parse` for code doing
+`using AAindex`.
 
 ## References
 


### PR DESCRIPTION
Prepares the repo to cut **0.4.0**.

## Changes

- **README.md** — rewritten for the 0.4.0 API. Adds `ids()` and no-arg `search()`, `Index` indexing by `Char` / code string, `AMatrix` indexing by integer or amino-acid pair plus `size`, and a note that `parse` is reached as `AAindex.parse` (intentionally not exported). Corrects the `Metadata` struct listing (`reference::Vector{String}`). All REPL outputs were re-verified against a live 0.4.0 session.
- **CHANGELOG.md** — `[0.4.0] - Unreleased` → `[0.4.0] - 2026-05-17`.

`Project.toml` is already at `version = "0.4.0"`. Full test suite passes (115/115).

## Release steps after merge

1. Merge this PR into `main`.
2. Comment `@JuliaRegistrator register` on the merge commit to register 0.4.0 in the General registry.
3. Once the registry PR auto-merges, `TagBot.yml` creates and pushes the `v0.4.0` git tag automatically — no manual tagging needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)